### PR TITLE
SUPPORT-145 Update output to use days as the max unit for display

### DIFF
--- a/lib/chronic_duration.rb
+++ b/lib/chronic_duration.rb
@@ -2,6 +2,18 @@ require 'numerizer' unless defined?(Numerizer)
 
 module ChronicDuration
 
+  HOURS_IN_DAY  = 8
+  DAYS_IN_WEEK  = 5
+  DAYS_IN_MONTH = 22
+  DAYS_IN_YEAR  = 260
+
+  MINUTE        = 60
+  HOUR          = 60 * MINUTE         # 3600
+  DAY           = HOURS_IN_DAY * HOUR # 28800
+  WEEK          = DAYS_IN_WEEK * DAY  # 144000
+  MONTH         = DAYS_IN_MONTH * DAY # 633600
+  YEAR          = DAYS_IN_YEAR * DAY  # 7488000
+
   extend self
 
   class DurationParseError < StandardError
@@ -41,29 +53,16 @@ module ChronicDuration
 
     decimal_places = seconds.to_s.split('.').last.length if seconds.is_a?(Float)
 
-    minute = 60
-    hour = 60 * minute
-    day = 8 * hour
-    month = 22 * day
-    year = 260 * day
-
-    if seconds >= 31557600 && seconds%year < seconds%month
-      years = seconds / year
-      months = seconds % year / month
-      days = seconds % year % month / day
-      hours = seconds % year % month % day / hour
-      minutes = seconds % year % month % day % hour / minute
-      seconds = seconds % year % month % day % hour % minute
-    elsif seconds >= 60
-      minutes = (seconds / 60).to_i
-      seconds = seconds % 60
-      if minutes >= 60
-        hours = (minutes / 60).to_i
-        minutes = (minutes % 60).to_i
+    if seconds >= 60
+      minutes = (seconds / MINUTE).to_i
+      seconds = seconds % MINUTE
+      if minutes >= MINUTE
+        hours = (minutes / MINUTE).to_i
+        minutes = (minutes % MINUTE).to_i
         if !opts[:limit_to_hours]
-          if hours >= 8
-            days = (hours / 8).to_i
-            hours = (hours % 8).to_i
+          if hours >= HOURS_IN_DAY
+            days = (hours / HOURS_IN_DAY).to_i
+            hours = (hours % HOURS_IN_DAY).to_i
           end
         end
       end
@@ -166,12 +165,12 @@ private
   def duration_units_seconds_multiplier(unit)
     return 0 unless duration_units_list.include?(unit)
     case unit
-    when 'years';   3600 * 8 * 260
-    when 'months';  3600 * 8 * 22
-    when 'weeks';   3600 * 8 * 5
-    when 'days';    3600 * 8
-    when 'hours';   3600
-    when 'minutes'; 60
+    when 'years';   YEAR
+    when 'months';  MONTH
+    when 'weeks';   WEEK
+    when 'days';    DAY
+    when 'hours';   HOUR
+    when 'minutes'; MINUTE
     when 'seconds'; 1
     end
   end

--- a/lib/chronic_duration/version.rb
+++ b/lib/chronic_duration/version.rb
@@ -1,3 +1,3 @@
 module ChronicDuration
-  VERSION = '0.11.2'
+  VERSION = '0.11.3'
 end

--- a/spec/lib/chronic_duration_spec.rb
+++ b/spec/lib/chronic_duration_spec.rb
@@ -13,21 +13,21 @@ describe ChronicDuration do
       'three mins four sec'          => 3 * 60 + 4,
       '2 hrs 20 min'          => 2 * 3600 + 20 * 60,
       '2h20min'               => 2 * 3600 + 20 * 60,
-      '6 mos 1 day'           => 6 * 30 * 24 * 3600 + 24 * 3600,
-      '1 year 6 mos 1 day'    => 1 * 31557600 + 6 * 30 * 24 * 3600 + 24 * 3600,
+      '6 mos 1 day'           => 6 * 22 * 8 * 3600 + 8 * 3600,
+      '1 year 6 mos 1 day'    => 1 * 7488000 + 6 * 22 * 8 * 3600 + 8 * 3600,
       '2.5 hrs'               => 2.5 * 3600,
-      '47 yrs 6 mos and 4.5d' => 47 * 31557600 + 6 * 30 * 24 * 3600 + 4.5 * 24 * 3600,
+      '47 yrs 6 mos and 4.5d' => 47 * 7488000 + 6 * 22 * 8 * 3600 + 4.5 * 8 * 3600,
       'two hours and twenty minutes' => 2 * 3600 + 20 * 60,
       'four hours and forty minutes' => 4 * 3600 + 40 * 60,
       'four hours, and fourty minutes' => 4 * 3600 + 40 * 60,
-      '3 weeks and, 2 days' => 3600 * 24 * 7 * 3 + 3600 * 24 * 2,
-      '3 weeks, plus 2 days' => 3600 * 24 * 7 * 3 + 3600 * 24 * 2,
-      '3 weeks with 2 days' => 3600 * 24 * 7 * 3 + 3600 * 24 * 2,
-      '1 month'               => 3600 * 24 * 30,
-      '2 months'              => 3600 * 24 * 30 * 2,
-      '18 months'             => 3600 * 24 * 30 * 18,
-      '1 year 6 months'       => (3600 * 24 * (365.25 + 6 * 30)).to_i,
-      'day'                   => 3600 * 24,
+      '3 weeks and, 2 days' => 3600 * 8 * 5 * 3 + 3600 * 8 * 2,
+      '3 weeks, plus 2 days' => 3600 * 8 * 5 * 3 + 3600 * 8 * 2,
+      '3 weeks with 2 days' => 3600 * 8 * 5 * 3 + 3600 * 8 * 2,
+      '1 month'               => 3600 * 8 * 22,
+      '2 months'              => 3600 * 8 * 22 * 2,
+      '18 months'             => 3600 * 8 * 22 * 18,
+      '1 year 6 months'       => (3600 * 8 * (260 + 6 * 22)).to_i,
+      'day'                   => 3600 * 8,
       'minute 30s'            => 90
     }
 
@@ -82,83 +82,75 @@ describe ChronicDuration do
     @exemplars = {
       (60 + 20) =>
         {
-          :micro    => '1m20s',
-          :short    => '1m 20s',
+          :micro    => '1min20s',
+          :short    => '1min 20s',
           :default  => '1 min 20 secs',
           :long     => '1 minute 20 seconds',
           :chrono   => '1:20'
         },
       (60 + 20.51) =>
         {
-          :micro    => '1m20.51s',
-          :short    => '1m 20.51s',
+          :micro    => '1min20.51s',
+          :short    => '1min 20.51s',
           :default  => '1 min 20.51 secs',
           :long     => '1 minute 20.51 seconds',
           :chrono   => '1:20.51'
         },
       (60 + 20.51928) =>
         {
-          :micro    => '1m20.51928s',
-          :short    => '1m 20.51928s',
+          :micro    => '1min20.51928s',
+          :short    => '1min 20.51928s',
           :default  => '1 min 20.51928 secs',
           :long     => '1 minute 20.51928 seconds',
           :chrono   => '1:20.51928'
         },
       (4 * 3600 + 60 + 1) =>
         {
-          :micro    => '4h1m1s',
-          :short    => '4h 1m 1s',
+          :micro    => '4h1min1s',
+          :short    => '4h 1min 1s',
           :default  => '4 hrs 1 min 1 sec',
           :long     => '4 hours 1 minute 1 second',
           :chrono   => '4:01:01'
         },
       (2 * 3600 + 20 * 60) =>
         {
-          :micro    => '2h20m',
-          :short    => '2h 20m',
-          :default  => '2 hrs 20 mins',
-          :long     => '2 hours 20 minutes',
-          :chrono   => '2:20'
-        },
-      (2 * 3600 + 20 * 60) =>
-        {
-          :micro    => '2h20m',
-          :short    => '2h 20m',
+          :micro    => '2h20min',
+          :short    => '2h 20min',
           :default  => '2 hrs 20 mins',
           :long     => '2 hours 20 minutes',
           :chrono   => '2:20:00'
         },
-      (6 * 30 * 24 * 3600 + 24 * 3600) =>
+      (6 * 22 * 8 * 3600 + 8 * 3600) =>
         {
-          :micro    => '6mo1d',
-          :short    => '6mo 1d',
-          :default  => '6 mos 1 day',
-          :long     => '6 months 1 day',
-          :chrono   => '6:01:00:00:00' # Yuck. FIXME
+          :micro    => '133d',
+          :short    => '133d',
+          :default  => '133 days',
+          :long     => '133 days',
+          :chrono   => '133:00:00:00' # Yuck. FIXME
         },
-      (365.25 * 24 * 3600 + 24 * 3600 ).to_i =>
+      (260 * 8 * 3600 + 8 * 3600 ).to_i =>
         {
-          :micro    => '1y1d',
-          :short    => '1y 1d',
-          :default  => '1 yr 1 day',
-          :long     => '1 year 1 day',
-          :chrono   => '1:00:01:00:00:00'
+          :micro    => '261d',
+          :short    => '261d',
+          :default  => '261 days',
+          :long     => '261 days',
+          :chrono   => '261:00:00:00'
         },
-      (3  * 365.25 * 24 * 3600 + 24 * 3600 ).to_i =>
+      (3 * 260 * 8 * 3600 + 8 * 3600 ).to_i =>
         {
-          :micro    => '3y1d',
-          :short    => '3y 1d',
-          :default  => '3 yrs 1 day',
-          :long     => '3 years 1 day',
-          :chrono   => '3:00:01:00:00:00'
+          :micro    => '781d',
+          :short    => '781d',
+          :default  => '781 days',
+          :long     => '781 days',
+          :chrono   => '781:00:00:00'
         },
-      (3600 * 24 * 30 * 18) =>
+      (3600 * 8 * 22 * 18) =>
         {
-          :micro    => '18mo',
-          :short    => '18mo',
-          :default  => '18 mos',
-          :long     => '18 months',
-          :chrono   => '18:00:00:00:00'
+          :micro    => '396d',
+          :short    => '396d',
+          :default  => '396 days',
+          :long     => '396 days',
+          :chrono   => '396:00:00:00'
         }
     }
 
@@ -197,17 +189,13 @@ describe ChronicDuration do
       end
     end
 
-    it "returns weeks when needed" do
-      ChronicDuration.output(45*24*60*60, :weeks => true).should =~ /.*wk.*/
-    end
-
     it "returns hours and minutes only when :hours_only option specified" do
       ChronicDuration.output(395*24*60*60 + 15*60, :limit_to_hours => true).should == '9480 hrs 15 mins'
     end
 
     it "returns the specified number of units if provided" do
       ChronicDuration.output(4 * 3600 + 60 + 1, units: 2).should == '4 hrs 1 min'
-      ChronicDuration.output(6 * 30 * 24 * 3600 + 24 * 3600 + 3600 + 60 + 1, units: 3, format: :long).should == '6 months 1 day 1 hour'
+      ChronicDuration.output(6 * 22 * 8 * 3600 + 8 * 3600 + 3600 + 60 + 1, units: 3, format: :long).should == '133 days 1 hour 1 minute'
     end
 
     context "when the format is not specified" do
@@ -259,7 +247,7 @@ describe ChronicDuration do
     end
 
     it "inserts spaces where there aren't any" do
-      ChronicDuration.instance_eval("cleanup('4m11.5s')").should == '4 minutes 11.5 seconds'
+      ChronicDuration.instance_eval("cleanup('4min11.5s')").should == '4 minutes 11.5 seconds'
     end
 
   end


### PR DESCRIPTION
[Aha! SUPPORT-145](https://big.aha.io/develop/features/SUPPORT-145)

## Summary
This PR makes three updates.

**1. Update `output` to show nothing larger than days**

There were two branches when formatting the `output` method.

```ruby
if seconds >= 31557600 && seconds%year < seconds%month
  # ...
elsif seconds >= 60
  # ...
end
```

The second branch is used when formatting output 99% of the time.  The first branch is only executed when the duration is in the first month of a year and at least 1 year in length (i.e. 2years and 1 day). The second part of this branch condition, `seconds%year < seconds%month`, exists in the main gem repo without context or reason as to why it exists.

The main difference between these two branches is that the first branch includes months and years when outputting the duration and the second branch shows nothing larger than days.  It does not make sense to show a different format for the 22 days of a year.  With this change, we remove this first branch and limit the largest unit of measure when displaying a duration to days.

**2. Add constants to clearly define time periods**

I refactored the code to clearly define time periods like the number of days in a year (`DAYS_IN_YEAR`).  I think this adds clarity to our work week based time periods.

**3. Update the specs**

Many of the specs were failing before this code change.  I made updates to the specs based on our code changes so that the specs pass again.