### PR TITLE
A-15854 Allow weeks and months to be used as units

### DIFF
--- a/lib/chronic_duration.rb
+++ b/lib/chronic_duration.rb
@@ -63,6 +63,17 @@ module ChronicDuration
           if hours >= HOURS_IN_DAY
             days = (hours / HOURS_IN_DAY).to_i
             hours = (hours % HOURS_IN_DAY).to_i
+            if opts[:allow_weeks] && days >= DAYS_IN_WEEK
+              weeks = (days / DAYS_IN_WEEK).to_i
+              days = (days % DAYS_IN_WEEK).to_i
+              if opts[:allow_months] && weeks >= 4
+                months = (weeks / 4).to_i
+                weeks = (weeks % 4).to_i
+              end
+            elsif opts[:allow_months] && days >= DAYS_IN_MONTH
+              months = (days / DAYS_IN_MONTH).to_i
+              days = (days % DAYS_IN_MONTH).to_i
+            end
           end
         end
       end
@@ -211,8 +222,8 @@ private
         raise DurationParseError, "An invalid word #{word.inspect} was used in the string to be parsed."
       end
     end
-    # add '1' at front if string starts with something recognizable but not with a number, like 'day' or 'minute 30sec' 
-    res.unshift(1) if res.length > 0 && mappings[res[0]]  
+    # add '1' at front if string starts with something recognizable but not with a number, like 'day' or 'minute 30sec'
+    res.unshift(1) if res.length > 0 && mappings[res[0]]
     res.join(' ')
   end
 

--- a/lib/chronic_duration.rb
+++ b/lib/chronic_duration.rb
@@ -63,14 +63,7 @@ module ChronicDuration
           if hours >= HOURS_IN_DAY
             days = (hours / HOURS_IN_DAY).to_i
             hours = (hours % HOURS_IN_DAY).to_i
-            if opts[:allow_weeks] && days >= DAYS_IN_WEEK
-              weeks = (days / DAYS_IN_WEEK).to_i
-              days = (days % DAYS_IN_WEEK).to_i
-              if opts[:allow_months] && weeks >= 4
-                months = (weeks / 4).to_i
-                weeks = (weeks % 4).to_i
-              end
-            elsif opts[:allow_months] && days >= DAYS_IN_MONTH
+            if opts[:allow_months] && days >= DAYS_IN_MONTH
               months = (days / DAYS_IN_MONTH).to_i
               days = (days % DAYS_IN_MONTH).to_i
             end

--- a/spec/lib/chronic_duration_spec.rb
+++ b/spec/lib/chronic_duration_spec.rb
@@ -162,6 +162,52 @@ describe ChronicDuration do
       end
     end
 
+    context "when expanded options" do
+
+      @longer_exemplars = {
+        (6 * 22 * 8 * 3600 + 8 * 3600) =>
+          {
+            :micro    => '6m3d',
+            :short    => '6m 3d',
+            :default  => '6 ms 3 days',
+            :long     => '6 months 3 days',
+            :chrono   => '6:03:00:00:00'
+          },
+        (260 * 8 * 3600 + 8 * 3600 ).to_i =>
+          {
+            :micro    => '13m1d',
+            :short    => '13m 1d',
+            :default  => '13 ms 1 day',
+            :long     => '13 months 1 day',
+            :chrono   => '13:01:00:00:00'
+          },
+        (3 * 260 * 8 * 3600 + 8 * 3600 ).to_i =>
+          {
+            :micro    => '39m1d',
+            :short    => '39m 1d',
+            :default  => '39 ms 1 day',
+            :long     => '39 months 1 day',
+            :chrono   => '39:01:00:00:00'
+          },
+        (3600 * 8 * 22 * 18) =>
+          {
+            :micro    => '19m1d',
+            :short    => '19m 1d',
+            :default  => '19 ms 1 day',
+            :long     => '19 months 1 day',
+            :chrono   => '19:01:00:00:00'
+          }
+      }
+
+      @longer_exemplars.each do |k, v|
+        v.each do |key, val|
+          it "properly outputs a duration of #{k} seconds as #{val} using the #{key.to_s} format option" do
+            ChronicDuration.output(k, allow_months: true, allow_weeks: true, format: key).should == val
+          end
+        end
+      end
+  end
+
     @keep_zero_exemplars = {
       (true) =>
       {
@@ -213,11 +259,11 @@ describe ChronicDuration do
         end
       end
     end
-    
+
     context "when the unit multiplier changes" do
-      
+
     end
-    
+
   end
 
   describe ".filter_by_type" do


### PR DESCRIPTION
We should allow for weeks and months to be used as units. To prevent it from being used by default, they will only take effect if an explicit option is passed in to allow it. 